### PR TITLE
Upgrade dependencies to run with webdrivercss 4.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
 	                },
                     // https://selenium-release.storage.googleapis.com/
                     ie: {
-                      version: '2.53.1',
+                      version: '3.0.0',
                       arch: 'ia32'
                     },
                     // https://github.com/operasoftware/operachromiumdriver/releases

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,19 +3,43 @@ module.exports = function(grunt) {
 	grunt.initConfig({
 		webdriver: {
 			test: {
-				configFile: './wdio.conf.js'
+				configFile: 'wdio.conf.js'
 			}
 		},
 	    'selenium_standalone': {
 	        serverConfig: {
-	            seleniumVersion: '2.48.2',
+	            seleniumVersion: '3.2.0',
 	            seleniumDownloadURL: 'http://selenium-release.storage.googleapis.com',
 	            drivers: {
+                    // http://chromedriver.storage.googleapis.com/
 	                chrome: {
-	                  version: '2.20',
-	                  arch: process.arch,
-	                  baseURL: 'http://chromedriver.storage.googleapis.com'
-	                }
+	                  version: '2.27'
+	                },
+                    // https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+	                edge: {
+	                  version: '3.14393'
+	                },
+                    // https://github.com/mozilla/geckodriver/releases
+	                firefox: {
+	                  version: '0.14.0'
+	                },
+                    // https://selenium-release.storage.googleapis.com/
+                    ie: {
+                      version: '2.53.1',
+                      arch: 'ia32'
+                    },
+                    // https://github.com/operasoftware/operachromiumdriver/releases
+	                opera: {
+	                  version: '0.2.2'
+	                },
+                    // https://bitbucket.org/ariya/phantomjs/downloads/
+	                phantomjs: {
+	                  version: '2.1.1'
+	                },
+                    // https://selenium-release.storage.googleapis.com/
+                    safari: {
+                      version: '2.48'
+                    }
 	            }
 	        }
 	    }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
-# WebdriverCSS with grunt demo project
+# WebdriverCSS with Grunt demo project
 
 ## Setup
 
-1. Install  GraphicsMagick https://github.com/webdriverio/webdrivercss/blob/master/README.md#install
-2. git clone this project.
-3. Run `npm install` from project root.
-4. Run `grunt test` from project root.
+1. Install Node.js.
+2. Run `npm install -g grunt-cli` to instal the global Grunt runner. You may need to elevate permissions by `sudo`.
+3. Install Java 8.
+4. Install GraphicsMagick - see https://github.com/webdriverio/webdrivercss/blob/master/README.md#install:
 
-The tests should run and create screenshots in the images folder now.
+    Ubuntu:  sudo apt-get install graphicsmagick
+    OSX:     brew install graphicsmagick
+    Windows: http://www.graphicsmagick.org/download.html
+
+5. Run `git clone https://github.com/chris-gunawardena/grunt-webdrivercss-example` to clone this project.
+6. Run `cd grunt-webdrivercss-example` to change current directory to the project root.
+7. Run `npm install` from the project root. You may want to send it to the background.
+8. Run `grunt test` from the project root.
+
+The tests should run and create screenshots in the `screenshots` folder now.
+
+Alternatively, you can start the welenium server and run the tests independently:
+
+8. Run `npm start` to start the Selenium server. You may need to send it to the background.
+9. Run `npm test`, whenever you need to test latest code changes.
+10. Run `npm stop` to stop the Selenium server.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 3. Install Java 8.
 4. Install GraphicsMagick - see https://github.com/webdriverio/webdrivercss/blob/master/README.md#install:
 
+```
     Ubuntu:  sudo apt-get install graphicsmagick
     OSX:     brew install graphicsmagick
     Windows: http://www.graphicsmagick.org/download.html
+```
 
 5. Run `git clone https://github.com/chris-gunawardena/grunt-webdrivercss-example` to clone this project.
 6. Run `cd grunt-webdrivercss-example` to change current directory to the project root.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@
 
 5. Run `git clone https://github.com/chris-gunawardena/grunt-webdrivercss-example` to clone this project.
 6. Run `cd grunt-webdrivercss-example` to change current directory to the project root.
-7. If you want to test with Edge, download the latest MicrosoftWebDriver.exe from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/ and save it to the project root.
-8. Run `npm install` from the project root. You may want to send it to the background.
-9. Run `grunt test` from the project root.
+7. Run `npm install` from the project root. You may want to send it to the background.
+8. If you want to test with Edge, download the latest MicrosoftWebDriver.exe from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/ and save it to the project root.
+9. If you want to test with PhantomJS, run `install phantomjs-prebuilt` from the project root.
+10. Run `grunt test` from the project root.
 
 The tests should run and create screenshots in the `screenshots` folder now.
 
 Alternatively, you can start the welenium server and run the tests independently:
 
-9. Run `npm start` to start the Selenium server. You may need to send it to the background.
-10. Run `npm test`, whenever you need to test latest code changes.
-11. Run `npm stop` to stop the Selenium server.
+10. Run `npm start` to start the Selenium server. You may need to send it to the background.
+11. Run `npm test`, whenever you need to test latest code changes.
+12. Run `npm stop` to stop the Selenium server.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@
 
 5. Run `git clone https://github.com/chris-gunawardena/grunt-webdrivercss-example` to clone this project.
 6. Run `cd grunt-webdrivercss-example` to change current directory to the project root.
-7. Run `npm install` from the project root. You may want to send it to the background.
-8. Run `grunt test` from the project root.
+7. If you want to test with Edge, download the latest MicrosoftWebDriver.exe from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/ and save it to the project root.
+8. Run `npm install` from the project root. You may want to send it to the background.
+9. Run `grunt test` from the project root.
 
 The tests should run and create screenshots in the `screenshots` folder now.
 
 Alternatively, you can start the welenium server and run the tests independently:
 
-8. Run `npm start` to start the Selenium server. You may need to send it to the background.
-9. Run `npm test`, whenever you need to test latest code changes.
-10. Run `npm stop` to stop the Selenium server.
+9. Run `npm start` to start the Selenium server. You may need to send it to the background.
+10. Run `npm test`, whenever you need to test latest code changes.
+11. Run `npm stop` to stop the Selenium server.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "grunt": "^1.0.1",
+    "grunt": "^0.4.5",
     "grunt-selenium-standalone": "^1.0.1",
     "grunt-webdriver": "^2.0.3",
     "http-tool": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,24 @@
 {
-  "name": "visual_regression",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "name": "grunt-webdrivercss-example",
+  "version": "2.0.0",
+  "description": "WebdriverCSS with grunt demo project",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "selenium-standalone install",
+    "start": "selenium-standalone start -- -role node -servlet org.openqa.grid.web.servlet.LifecycleServlet -registerCycle 0 -port 4444",
+    "stop": "http-tool http://localhost:4444/extra/LifecycleServlet?action=shutdown",
+    "test": "grunt webdriver"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "grunt": "^0.4.5",
-    "grunt-selenium-standalone": "^0.1.2",
-    "grunt-webdriver": "^1.0.0",
-    "mocha": "^2.3.4",
-    "phantomjs": "^1.9.19",
-    "webdrivercss": "^2.0.0-beta-rc1",
-    "webdriverio": "^3.4.0"
+    "grunt": "^1.0.1",
+    "grunt-selenium-standalone": "^1.0.1",
+    "grunt-webdriver": "^2.0.3",
+    "http-tool": "^0.4.0",
+    "selenium-standalone": "^6.0.1",
+    "selenium-webdriver": "^3.3.0",
+    "wdio-mocha-framework": "^0.5.9",
+    "webdrivercss": "visualregressiontesting/webdrivercss",
+    "webdriverio": "^4.6.2"
   }
 }

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -29,7 +29,8 @@ exports.config = {
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
-    // Browsers: chrome, edge, firefox, ie, opera, phantomjs, safari
+    // Browsers: chrome, edge, firefox, internet explorer, opera, phantomjs, safari
+    // See https://medium.com/@jlchereau/how-to-configure-webdrivier-io-with-selenium-standalone-and-additional-browsers-9369d38bc4d1 for more information.
     // See http://docs.seleniumhq.org/download/ for available versions.
     //
     capabilities: [{

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -33,6 +33,9 @@ exports.config = {
     // See https://medium.com/@jlchereau/how-to-configure-webdrivier-io-with-selenium-standalone-and-additional-browsers-9369d38bc4d1 for more information.
     // See http://docs.seleniumhq.org/download/ for available versions.
     //
+    // Add 'phantomjs.binary.path': require('path').join(__dirname, 'node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs.exe')
+    // to capabilities for browserName == 'phantomjs' on Windows.
+    //
     capabilities: [{
         browserName: 'chrome'
     }],

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -29,7 +29,7 @@ exports.config = {
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
-    // Browsers: chrome, edge, firefox, internet explorer, opera, phantomjs, safari
+    // Browsers: chrome, firefox, internet explorer, MicrosoftEdge, opera, phantomjs, safari
     // See https://medium.com/@jlchereau/how-to-configure-webdrivier-io-with-selenium-standalone-and-additional-browsers-9369d38bc4d1 for more information.
     // See http://docs.seleniumhq.org/download/ for available versions.
     //

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -29,6 +29,9 @@ exports.config = {
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
     // https://docs.saucelabs.com/reference/platforms-configurator
     //
+    // Browsers: chrome, edge, firefox, ie, opera, phantomjs, safari
+    // See http://docs.seleniumhq.org/download/ for available versions.
+    //
     capabilities: [{
         browserName: 'chrome'
     }],
@@ -79,9 +82,9 @@ exports.config = {
     //
     // Make sure you have the node package for the specific framework installed before running
     // any tests. If not please install the following package:
-    // Mocha: `$ npm install mocha`
-    // Jasmine: `$ npm install jasmine`
-    // Cucumber: `$ npm install cucumber`
+    // Mocha: `$ npm install wdio-mocha-framework`
+    // Jasmine: `$ npm install wdio-jasmine-framework`
+    // Cucumber: `$ npm install wdio-cucumber-framework`
     framework: 'mocha',
     //
     // Test reporter for stdout.


### PR DESCRIPTION
Switch to the visualregressiontesting/webdrivercss fork to support the most recent webdrivercss 4.x. See http://blog.kevinlamping.com/a-stop-gap-for-webdrivercss/.

Add an alternative to run the tests without staring and stopping the server for every test run by npm scripts.

Depend on wdio-mocha-framework instead of mocha.

Remove phantomjs dependency. wdio.conf.js refers to chrome and driver dependencies should be handled by selenium webdriver implementations.

Improve the documentation.